### PR TITLE
PI-510 The app does not continue uploading process when user open the app again

### DIFF
--- a/src/main/processes/shared/database.js
+++ b/src/main/processes/shared/database.js
@@ -76,18 +76,5 @@ export default {
     await File.delete(file => FileState.isCompleted(file.state) && FileHelper.isOutdatedFile(file))
     console.log('deleting outdated files complete')
     return Promise.resolve()
-  },
-  // other
-  toggleUploadingProcess: (event, files, isToggledUploadingProcess) => {
-    console.log(`toggleUploadingSession ${files.length} ${isToggledUploadingProcess}`)
-    const updatedFiles = files.reduce((result, file) => {
-      result[file.id] = { ...file, paused: !isToggledUploadingProcess }
-      return result
-    }, {})
-    store.commit('entities/insertRecords', {
-      entity: 'files',
-      records: updatedFiles
-    })
-    event.sender.send('toggleUploadingSessionComplete')
   }
 }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -38,46 +38,13 @@
         this.onLine = type === 'online'
         if (!this.onLine) {
           console.log('\nupdateOnlineStatus', this.onLine)
-          this.updateUploadingProcess(this.onLine)
           settings.set('settings.onLine', this.onLine)
-          this.checkAfterSuspended()
         } else {
           isOnline().then(online => {
             console.log('\nupdateOnlineStatus', online)
-            this.updateUploadingProcess(online)
             settings.set('settings.onLine', online)
           })
         }
-      },
-      updateUploadingProcess (arg) {
-        const files = this.getAllFilesInTheSession()
-        files.forEach(file => {
-          File.update({ where: file.id,
-            data: { paused: !arg }
-          })
-        })
-      },
-      checkAfterSuspended () {
-        return this.getSuspendedFiles()
-          .then((files) => {
-            if (files.length) {
-              let listener = (event, arg) => {
-                this.$electron.ipcRenderer.removeListener('sendIdToken', listener)
-                let idToken = arg
-                for (let file of files) {
-                  return this.$file.checkStatus(file, idToken, true)
-                }
-              }
-              this.$electron.ipcRenderer.send('getIdToken')
-              this.$electron.ipcRenderer.on('sendIdToken', listener)
-            }
-          })
-      },
-      getSuspendedFiles () {
-        return new Promise((resolve, reject) => {
-          let files = File.query().where(file => { return file.state === 'uploading' && file.uploadId !== '' && file.uploaded === false }).orderBy('timestamp').get()
-          resolve(files != null ? files : [])
-        })
       }
     }
   }

--- a/src/renderer/components/APIService.vue
+++ b/src/renderer/components/APIService.vue
@@ -21,7 +21,8 @@
     },
     computed: {
       ...mapState({
-        currentUploadingSessionId: state => state.AppSetting.currentUploadingSessionId
+        currentUploadingSessionId: state => state.AppSetting.currentUploadingSessionId,
+        isUploadingProcessEnabled: state => state.AppSetting.isUploadingProcessEnabled
       }),
       filesInUploadingSession () {
         if (!this.currentUploadingSessionId) return []
@@ -29,14 +30,11 @@
       },
       noDurationFiles () {
         return File.query().where(file => { return file.state === 'preparing' && file.durationInSecond === -1 }).orderBy('timestamp').get()
-      },
-      isUploadingProcessEnabled () {
-        const files = this.getAllFilesInTheSession()
-        return files.every(file => { return !file.paused })
       }
     },
     watch: {
       isUploadingProcessEnabled (val, oldVal) {
+        console.log('isUploadingProcessEnabled set', val, oldVal)
         if (val === oldVal) return
         this.checkStatusWorkerTimeout = workerTimeoutMinimum
         this.tickCheckStatus()
@@ -168,21 +166,6 @@
       resetUploadingSessionId () {
         this.$store.dispatch('setCurrentUploadingSessionId', null)
       }
-    },
-    mounted () {
-      let listener = (event, arg) => {
-        this.$electron.ipcRenderer.removeListener('suspendApp', listener)
-        // Continue uploading process if the app resumes
-        const files = this.getAllFilesInTheSession()
-        files.forEach(file => {
-          File.update({ where: file.id,
-            data: { paused: !arg }
-          })
-        })
-        this.$electron.ipcRenderer.send('setUploadingProcess', arg)
-        if (arg === true) { this.checkAfterSuspended() }
-      }
-      this.$electron.ipcRenderer.on('suspendApp', listener)
     },
     created () {
       console.log('API Service')

--- a/src/renderer/components/EditStreamLocation/EditStreamLocationPage.vue
+++ b/src/renderer/components/EditStreamLocation/EditStreamLocationPage.vue
@@ -188,13 +188,6 @@ export default {
       if (stream) {
         this.$store.dispatch('setSelectedStreamId', stream.id)
       }
-      // If a stream deleted when the uploading process was paused.
-      const files = File.query().where('sessionId', this.currentUploadingSessionId).get()
-      files.forEach(file => {
-        File.update({ where: file.id,
-          data: { paused: false }
-        })
-      })
       this.isDeleting = false
       this.redirectToMainScreen()
     },

--- a/src/renderer/components/LandingPage.vue
+++ b/src/renderer/components/LandingPage.vue
@@ -51,7 +51,6 @@
     components: { SideNavigation, EmptyView, FileList, FileContainer, GlobalProgress, ConfirmAlert },
     data () {
       return {
-        uploadingProcessText: 'The uploading process has been paused',
         alertTitle: 'You are up to date',
         alertContent: this.getContent(),
         executed: false,

--- a/src/renderer/components/LandingPage/FileContainer/FileNameFormatInfo.vue
+++ b/src/renderer/components/LandingPage/FileContainer/FileNameFormatInfo.vue
@@ -122,6 +122,9 @@ export default {
       const tabObject = {}
       tabObject[this.selectedStreamId] = 'Queued'
       this.$store.dispatch('setSelectedTab', tabObject)
+
+      // always enable uploading process
+      this.$store.dispatch('enableUploadingProcess', true)
     },
     confirmToClearAllFiles () {
       this.clearAllFiles()

--- a/src/renderer/components/SideNavigation/GlobalProgress.vue
+++ b/src/renderer/components/SideNavigation/GlobalProgress.vue
@@ -17,14 +17,10 @@
 import { mapState } from 'vuex'
 import File from '../../store/models/File'
 export default {
-  data () {
-    return {
-      isUploadingProcessEnabled: true
-    }
-  },
   computed: {
     ...mapState({
-      currentUploadingSessionId: state => state.AppSetting.currentUploadingSessionId
+      currentUploadingSessionId: state => state.AppSetting.currentUploadingSessionId,
+      isUploadingProcessEnabled: state => state.AppSetting.isUploadingProcessEnabled
     }),
     shouldShowProgress () {
       const allFiles = this.getAllFilesInTheSession()
@@ -33,10 +29,6 @@ export default {
     completedFiles () {
       const files = this.getAllFilesInTheSession()
       return files.filter(f => f.isInCompletedGroup)
-    },
-    isUploadingEnabled () {
-      const files = this.getAllFilesInTheSession()
-      return files.every(file => { return !file.paused })
     }
   },
   watch: {
@@ -63,13 +55,8 @@ export default {
       return require(`../../assets/ic-uploading-${state}-green.svg`)
     },
     toggleUploadingProcess () {
-      this.isUploadingProcessEnabled = !this.isUploadingProcessEnabled
-      const files = this.getAllFilesInTheSession()
-      files.forEach(file => {
-        File.update({ where: file.id,
-          data: { paused: !this.isUploadingProcessEnabled }
-        })
-      })
+      // this.isUploadingProcessEnabled = !this.isUploadingProcessEnabled
+      this.$store.dispatch('enableUploadingProcess', !this.isUploadingProcessEnabled)
     },
     getProgressPercent () {
       const files = this.getAllFilesInTheSession()

--- a/src/renderer/store/models/File.js
+++ b/src/renderer/store/models/File.js
@@ -31,7 +31,6 @@ export default class File extends Model {
       notified: this.boolean(false),
       retries: this.number(0),
       uploaded: this.boolean(false),
-      paused: this.boolean(false),
       sessionId: this.attr(''),
       deviceId: this.string(''),
       deploymentId: this.string('')

--- a/src/renderer/store/modules/AppSetting.js
+++ b/src/renderer/store/modules/AppSetting.js
@@ -1,6 +1,7 @@
 const state = {
   selectedTabs: {},
-  currentUploadingSessionId: null
+  currentUploadingSessionId: null,
+  isUploadingProcessEnabled: true
 }
 
 const mutations = {
@@ -10,9 +11,13 @@ const mutations = {
   SET_UPLOADING_SESSION_ID (state, id) {
     state.currentUploadingSessionId = id
   },
+  ENABLE_UPLOADING_PROCESS (state, enabled) {
+    state.isUploadingProcessEnabled = enabled
+  },
   RESET (state, object) {
     state.selectedTabs = object
     state.currentUploadingSessionId = null
+    state.isUploadingProcessEnabled = true
   }
 }
 
@@ -22,6 +27,9 @@ const actions = {
   },
   setCurrentUploadingSessionId ({ commit }, id) {
     commit('SET_UPLOADING_SESSION_ID', id)
+  },
+  enableUploadingProcess ({ commit }, enabled) {
+    commit('ENABLE_UPLOADING_PROCESS', enabled)
   },
   reset ({ commit }, object) {
     commit('RESET', object)


### PR DESCRIPTION
## ✅ DoD
- [x] The app should be able to pause the uploading process when the user clicks the pause button
- [x] The app should be able to resume the uploading process quickly when the user opens the app again (if the user hasn't paused it before he/she leaves the app) 

## 📝 Summary
Change the way to handle the pause/resume uploading process to a boolean state in Vuex, instead of checking 'paused' status of every file in the uploading session. This will be affected:
| No | From | To |
| --- | ----- | --- |
| 1 | The app used to resume the uploading process automatically when the user opens the app again or when the online status has changed (it doesn't care if the user has paused the process or not before they leave the app or lost their connection) | The app will auto-resume the uploading process if the user hasn't paused before he/she leaves the app |
| 2 | The app used to be very slow when the user click pause/resume as it tried to update paused status of every file in the session | The app will only update one boolean value in Vuex to pause/resume |
| 3 | When the user starts to upload more files into a paused session, the app will just put files into the queue, but the uploading session is still paused | Auto resume the uploading session when the user click Start Upload a new batch of files into the queue |
