### PR TITLE
CE-413 Change ingesting status to be processing and move it to Completed tab

### DIFF
--- a/src/renderer/services/file.js
+++ b/src/renderer/services/file.js
@@ -316,7 +316,7 @@ class FileProvider {
       // FIX progress scale when we will start work with google cloud
     }).then((uploadId) => {
       console.log(`\n ===> file uploaded to the temp folder S3 ${file.name} ${uploadId}`)
-      return File.update({ where: file.id, data: { uploaded: true, uploadedTime: Date.now() } })
+      return File.update({ where: file.id, data: { uploaded: true, uploadedTime: Date.now(), state: 'ingesting', stateMessage: '' } })
     }).catch((error) => {
       console.log('===> ERROR UPLOAD FILE', file.name, error.message)
       if (error.message === 'Request body larger than maxBodyLength limit') {

--- a/utils/fileState.js
+++ b/utils/fileState.js
@@ -18,7 +18,7 @@ const getName = function (state, message) {
     case 'converting': return 'compressing'
     case 'waiting': return 'waiting'
     case 'uploading': return 'uploading'
-    case 'ingesting': return 'ingesting'
+    case 'ingesting': return 'processing'
     case 'local_error':
     case 'server_error':
       if (!message) return ''
@@ -54,11 +54,11 @@ const isInPreparedGroup = function (state) {
 }
 
 const isInQueuedGroup = function (state) {
-  return ['waiting', 'uploading', 'converting', 'ingesting'].includes(state)
+  return ['waiting', 'uploading', 'converting'].includes(state)
 }
 
 const isInCompletedGroup = function (state) {
-  return state === 'completed' || state === 'server_error' || state === 'failed'
+  return ['completed', 'ingesting', 'server_error', 'failed'].includes(state)
 }
 
 const isPreparing = function (state) {


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-413](https://jira.rfcx.org/browse/CE-413)

## 📝 Summary

After the file has been uploaded and the job has been queued, we should move it into Completed. And then add a Processing label that appears next to audio in the Completed tab until it hears back from the Ingest Service if that file got ingested or not. It will allow the user to proceed while our backend ingestion is working and it will ensure that a user is always uploading as many parallel files as possible.

## 📸 Attachments

https://user-images.githubusercontent.com/9149523/112418621-6c650700-8d5c-11eb-9860-ef5527045354.mov
